### PR TITLE
Hotfix: on `composer du` the `autoload` file is determined correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.0.0 under development
 
-- Changed namespace to `Yiisoft/Composer/Config` (sadmark)
+- Chg: Changed namespace to `Yiisoft/Composer/Config` (sadmark)
+- Fix #1: Use Composer to determine vendor directory (roxblnfk)
 
 ## [0.4.0] - 2020-03-08
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -86,13 +86,13 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * This is the main function.
      */
-    public function onPostAutoloadDump(): void
+    public function onPostAutoloadDump(Event $event): void
     {
         $this->io->overwriteError('<info>Assembling config files</info>');
 
         $this->builder = new Builder();
 
-        $this->initAutoload();
+        require_once $event->getComposer()->getConfig()->get('vendor-dir') . '/autoload.php';
         $this->scanPackages();
         $this->reorderFiles();
         $this->showDepsTree();
@@ -109,12 +109,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $this->addFiles($this->rootPackage, $files);
             $builder->buildAllConfigs($this->files);
         }
-    }
-
-    protected function initAutoload(): void
-    {
-        $dir = dirname(__DIR__, 3);
-        require_once "$dir/autoload.php";
     }
 
     protected function scanPackages(): void


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bugfix?              | ✔️
| Feature?             | ❌
| Break compatibility? | ✔️
| Tests pass?          | ✔️

Now the path to the `autoload` file is determined correctly when `composer du` is called
