### PR TITLE
Reader is context-aware, enhanced tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
             <directory>./tests/unit/</directory>
         </testsuite>
         <testsuite name="Integration Test Suite">
-            <directory>./tests/Integration/</directory>
+            <directory>./tests/Integration/Tests</directory>
         </testsuite>
     </testsuites>
     <extensions>

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -55,7 +55,7 @@ class Builder
     {
         $this->outputDir = $outputDir
             ? static::buildAbsPath($this->getBaseDir(), $outputDir)
-            : $this->findOutputDir();
+            : static::findOutputDir();
     }
 
     public static function rebuild(string $outputDir = null): void

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -36,7 +36,7 @@ class Builder
     public function __construct(ConfigFactory $configFactory, string $baseDir = null)
     {
         $this->configFactory = $configFactory;
-        $this->setBaseDir($baseDir);
+        $this->baseDir = $baseDir;
         $this->outputDir = self::findOutputDir($baseDir);
     }
 
@@ -206,13 +206,5 @@ class Builder
     public function getBaseDir(): string
     {
         return $this->baseDir;
-    }
-
-    /**
-     * @param string $baseDir
-     */
-    private function setBaseDir(string $baseDir): void
-    {
-        $this->baseDir = $baseDir;
     }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -201,9 +201,9 @@ class Builder
     }
 
     /**
-     * @return string
+     * @return string a full path to the project root
      */
-    private function getBaseDir(): string
+    public function getBaseDir(): string
     {
         return $this->baseDir;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -17,7 +17,7 @@ class Builder
     private const OUTPUT_DIR_SUFFIX = '-output';
 
     /**
-     * @var string path to the composer project root
+     * @var string path to the Composer project root
      */
     private string $baseDir;
 
@@ -33,7 +33,13 @@ class Builder
 
     private ConfigFactory $configFactory;
 
-    public function __construct(ConfigFactory $configFactory, string $baseDir = null)
+    /**
+     * Builder constructor.
+     *
+     * @param ConfigFactory $configFactory
+     * @param string $baseDir path to the Composer project root
+     */
+    public function __construct(ConfigFactory $configFactory, string $baseDir)
     {
         $this->configFactory = $configFactory;
         $this->baseDir = $baseDir;
@@ -55,7 +61,7 @@ class Builder
     {
         $this->outputDir = $outputDir
             ? static::buildAbsPath($this->getBaseDir(), $outputDir)
-            : static::findOutputDir();
+            : static::findOutputDir($this->getBaseDir());
     }
 
     public static function rebuild(string $outputDir = null): void
@@ -68,7 +74,9 @@ class Builder
     /**
      * Returns default output dir.
      *
-     * @param string $baseDir path to project base dir
+     * @param string|null $baseDir path to the root Composer package. When `null`,
+     * {@see findBaseDir()} will be called to find a base dir.
+     *
      * @return string
      * @throws JsonException
      */

--- a/src/Configs/Config.php
+++ b/src/Configs/Config.php
@@ -167,8 +167,8 @@ class Config
 
     private function findDepth(): int
     {
-        $outDir = dirname($this->normalizePath($this->getOutputPath()));
-        $diff = substr($outDir, strlen($this->getBaseDir()));
+        $outDir = realpath(dirname($this->normalizePath($this->getOutputPath())));
+        $diff = substr($outDir, strlen(realpath($this->getBaseDir())));
 
         return substr_count($diff, '/');
     }
@@ -267,7 +267,7 @@ class Config
 
     private function getBaseDir(): string
     {
-        return dirname(__DIR__, 5);
+        return $this->builder->getBaseDir();
     }
 
     protected function getOutputPath(string $name = null): string

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -68,7 +68,7 @@ final class Plugin
     {
         $this->composer = $composer;
         $baseDir = $this->composer->getConfig()->get('vendor-dir') . '/../';
-        $this->builder = new Builder(new ConfigFactory(), $baseDir);
+        $this->builder = new Builder(new ConfigFactory(), realpath($baseDir));
         $this->packageFinder = new PackageFinder($composer);
         $this->aliasesCollector = new AliasesCollector(new Filesystem());
         $this->io = $io;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -45,11 +45,6 @@ final class Plugin
     private Builder $builder;
 
     /**
-     * @var Composer instance
-     */
-    private Composer $composer;
-
-    /**
      * @var IOInterface
      */
     private IOInterface $io;
@@ -66,8 +61,7 @@ final class Plugin
      */
     public function __construct(Composer $composer, IOInterface $io)
     {
-        $this->composer = $composer;
-        $baseDir = $this->composer->getConfig()->get('vendor-dir') . '/../';
+        $baseDir = dirname($composer->getConfig()->get('vendor-dir')) . DIRECTORY_SEPARATOR;
         $this->builder = new Builder(new ConfigFactory(), realpath($baseDir));
         $this->packageFinder = new PackageFinder($composer);
         $this->aliasesCollector = new AliasesCollector(new Filesystem());

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -66,10 +66,11 @@ final class Plugin
      */
     public function __construct(Composer $composer, IOInterface $io)
     {
-        $this->builder = new Builder(new ConfigFactory());
+        $this->composer = $composer;
+        $baseDir = $this->composer->getConfig()->get('vendor-dir') . '/../';
+        $this->builder = new Builder(new ConfigFactory(), $baseDir);
         $this->packageFinder = new PackageFinder($composer);
         $this->aliasesCollector = new AliasesCollector(new Filesystem());
-        $this->composer = $composer;
         $this->io = $io;
     }
 
@@ -80,7 +81,6 @@ final class Plugin
         $this->scanPackages();
         $this->reorderFiles();
 
-        $this->builder->setOutputDir($this->outputDir);
         $this->builder->buildAllConfigs($this->files);
 
         $saveFiles = $this->files;

--- a/src/Readers/ReaderFactory.php
+++ b/src/Readers/ReaderFactory.php
@@ -32,11 +32,12 @@ class ReaderFactory
         $type = static::detectType($path);
         $class = static::findClass($type);
 
-        if (!array_key_exists($class, self::$loaders)) {
-            self::$loaders[$class] = static::create($builder, $type);
+        $uniqid = $class . ':' . spl_object_hash($builder);
+        if (empty(self::$loaders[$uniqid])) {
+            self::$loaders[$uniqid] = static::create($builder, $type);
         }
 
-        return self::$loaders[$class];
+        return self::$loaders[$uniqid];
     }
 
     private static function detectType(string $path): string

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -13,7 +13,8 @@
         "first-dev-vendor/first-package": "*",
         "first-dev-vendor/second-package": "*",
         "second-dev-vendor/first-package": "*",
-        "second-dev-vendor/second-package": "*"
+        "second-dev-vendor/second-package": "*",
+        "vlucas/phpdotenv": "*"
     },
     "repositories": [
         {
@@ -64,6 +65,15 @@
             "params": "config/params.php",
             "test": "config/test.php",
             "web": "config/web.php"
-        }
+        },
+        "config-plugin-alternatives": "config/alternatives.json"
+    },
+    "scripts": {
+        "symlink-package": [
+            "rm -rf vendor/yiisoft/composer-config-plugin",
+            "ln -s ../../../ vendor/yiisoft/composer-config-plugin"
+        ],
+        "post-install-cmd": "@symlink-package",
+        "post-update-cmd": "@symlink-package"
     }
 }

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -71,7 +71,8 @@
     "scripts": {
         "symlink-package": [
             "rm -rf vendor/yiisoft/composer-config-plugin",
-            "ln -s ../../../ vendor/yiisoft/composer-config-plugin"
+            "ln -s ../../../../../ vendor/yiisoft/composer-config-plugin",
+            "@composer dump"
         ],
         "post-install-cmd": "@symlink-package",
         "post-update-cmd": "@symlink-package"

--- a/tests/Integration/Environment/config/alt/yiiframework.com.env
+++ b/tests/Integration/Environment/config/alt/yiiframework.com.env
@@ -1,0 +1,1 @@
+ENV_PARAMETER=yiiframework.com

--- a/tests/Integration/Environment/config/alt/yiiframework.ru-beta.env
+++ b/tests/Integration/Environment/config/alt/yiiframework.ru-beta.env
@@ -1,0 +1,1 @@
+ENV_PARAMETER=beta.yiiframework.ru

--- a/tests/Integration/Environment/config/alt/yiiframework.ru.env
+++ b/tests/Integration/Environment/config/alt/yiiframework.ru.env
@@ -1,0 +1,1 @@
+ENV_PARAMETER=yiiframework.ru

--- a/tests/Integration/Environment/config/alternatives.json
+++ b/tests/Integration/Environment/config/alternatives.json
@@ -1,0 +1,12 @@
+{
+    "yiiframework.com": {
+        "dotenv": "config/alt/yiiframework.com.env"
+    },
+
+    "yiiframework.ru": {
+        "dotenv": [
+            "config/alt/yiiframework.ru.env",
+            "config/alt/yiiframework.ru-beta.env"
+        ]
+    }
+}

--- a/tests/Integration/Environment/config/params.php
+++ b/tests/Integration/Environment/config/params.php
@@ -22,4 +22,6 @@ return [
     // 'short callable parameter' => fn() => 'I am callable',
 
     'object parameter' => new stdClass(),
+
+    'env_parameter' => 'default',
 ];

--- a/tests/Integration/Environment/config/web.php
+++ b/tests/Integration/Environment/config/web.php
@@ -4,4 +4,5 @@ declare(strict_types=1);
 
 return [
     \Environment\Serializer\SerializerInterface::class => \Environment\Serializer\PhpSerializer::class,
+    'params' => $params,
 ];

--- a/tests/Integration/Tests/Config/AlternativesTest.php
+++ b/tests/Integration/Tests/Config/AlternativesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
+
+final class AlternativesTest extends ConfigTest
+{
+    public function configProvider(): array
+    {
+        return [
+            [
+                'env_parameter',
+                fn(string $param) => $this->assertSame('yiiframework.com', $param),
+                'yiiframework.com/params'
+            ],
+            [
+                'params',
+                fn(array $params) => $this->assertSame('yiiframework.com', $params['env_parameter']),
+                'yiiframework.com/web'
+            ],
+            [
+                'params',
+                fn(array $params) => $this->assertSame('beta.yiiframework.ru', $params['env_parameter']),
+                'yiiframework.ru/web'
+            ],
+        ];
+    }
+
+    protected function getDefaultConfigName(): string
+    {
+        return 'web';
+    }
+}

--- a/tests/Integration/Tests/Config/ConfigTest.php
+++ b/tests/Integration/Tests/Config/ConfigTest.php
@@ -4,30 +4,44 @@ declare(strict_types=1);
 
 namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
 
+use Closure;
+use Yiisoft\Composer\Config\Tests\Integration\Tests\Helper\LiterallyCallback;
 use Yiisoft\Composer\Config\Tests\Integration\Tests\PluginTestCase;
 
 abstract class ConfigTest extends PluginTestCase
 {
     protected function setUp(): void
     {
-        $this->registerConfig($this->getConfigName());
+        $this->registerConfig($this->getDefaultConfigName());
     }
 
     /**
      * @dataProvider configProvider()
      * @param string $name
      * @param $expectedValue
+     * @param string|null $configName
      */
-    public function testConfig(string $name, $expectedValue): void
+    public function testConfig(string $name, $expectedValue, string $configName = null): void
     {
-        $actualValue = $this->getConfigValue($name);
+        $actualValue = $this->getConfigValue($name, $configName);
+        if ($expectedValue instanceof Closure) {
+            $expectedValue($actualValue);
+            return;
+        }
+        if ($expectedValue instanceof LiterallyCallback) {
+            $expectedValue = $expectedValue->getCallback();
+        }
+
         $this->assertEquals($expectedValue, $actualValue);
     }
 
-    protected function getConfigValue(string $name)
+    protected function getConfigValue(string $name, string $configName = null)
     {
-        return $this->getFromConfig($this->getConfigName(), $name);
+        if ($configName !== null) {
+            $this->registerConfig($configName);
+        }
+        return $this->getFromConfig($configName ?? $this->getDefaultConfigName(), $name);
     }
 
-    abstract protected function getConfigName(): string;
+    abstract protected function getDefaultConfigName(): string;
 }

--- a/tests/Integration/Tests/Config/ParamsConfigTest.php
+++ b/tests/Integration/Tests/Config/ParamsConfigTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
 
 use stdClass;
+use Yiisoft\Composer\Config\Tests\Integration\Tests\Helper\LiterallyCallback;
 
 final class ParamsConfigTest extends ConfigTest
 {
@@ -20,15 +21,15 @@ final class ParamsConfigTest extends ConfigTest
             ['array parameter', [[[[[[]]]]]]],
             [
                 'callable parameter',
-                function () {
+                new LiterallyCallback(function () {
                     return 'I am callable';
-                },
+                }),
             ],
             [
                 'static callable parameter',
-                static function () {
+                new LiterallyCallback(static function () {
                     return 'I am callable';
-                },
+                }),
             ],
             ['object parameter', new stdClass()],
             /**
@@ -45,7 +46,7 @@ final class ParamsConfigTest extends ConfigTest
         ];
     }
 
-    protected function getConfigName(): string
+    protected function getDefaultConfigName(): string
     {
         return 'params';
     }

--- a/tests/Integration/Tests/Config/TestConfigTest.php
+++ b/tests/Integration/Tests/Config/TestConfigTest.php
@@ -16,7 +16,7 @@ final class TestConfigTest extends ConfigTest
         ];
     }
 
-    protected function getConfigName(): string
+    protected function getDefaultConfigName(): string
     {
         return 'test';
     }

--- a/tests/Integration/Tests/Config/WebConfigTest.php
+++ b/tests/Integration/Tests/Config/WebConfigTest.php
@@ -13,10 +13,14 @@ final class WebConfigTest extends ConfigTest
                 \Environment\Serializer\SerializerInterface::class,
                 \Environment\Serializer\PhpSerializer::class,
             ],
+            [
+                'params',
+                fn(array $params) => $this->assertSame('default', $params['env_parameter']),
+            ],
         ];
     }
 
-    protected function getConfigName(): string
+    protected function getDefaultConfigName(): string
     {
         return 'web';
     }

--- a/tests/Integration/Tests/Helper/LiterallyCallback.php
+++ b/tests/Integration/Tests/Helper/LiterallyCallback.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Helper;
+
+use Closure;
+
+final class LiterallyCallback
+{
+    /**
+     * @var Closure
+     */
+    private Closure $callback;
+
+    public function __construct(Closure $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @return Closure
+     */
+    public function getCallback(): Closure
+    {
+        return $this->callback;
+    }
+}

--- a/tests/unit/Readers/ReaderFactoryTest.php
+++ b/tests/unit/Readers/ReaderFactoryTest.php
@@ -23,8 +23,8 @@ class ReaderFactoryTest extends \PHPUnit\Framework\TestCase
         $php = $this->checkGet('.php', PhpReader::class);
         $php2 = $this->checkGet('.php', PhpReader::class);
 
-        $this->assertSame($php, $php2);
-        $this->assertSame($yml, $yaml);
+        $this->assertNotSame($php, $php2);
+        $this->assertNotSame($yml, $yaml);
     }
 
     public function checkGet(string $name, string $class)


### PR DESCRIPTION
The main change of this PR is in ReaderFactory:35-40 and addresses the regression.

During the refactoring, ReaderFactory behavior was optimized to
create at most one reader for each type. However, the reader was designed to be context-aware,
otherwise, alternatives building does not work properly.

This PR also contains Integration suite enhancements:
 - Symlink current project dir with composer-config-plugin instead of installing it from Packagist
 - Fixed path detection to rely on Composer instead of blindly-guessing it from dirs hierarchy (fixes for the previous point)
 - Reduce Integration Test Suite scope to prevent scanning of Integration/Environment/vendor dir

| Q                    | A
| -------------------- | ---
| Bugfix?              | ✔️
| Feature?             | ❌
| Break compatibility? | ✔️
| Tests pass?          | ✔️
