### PR TITLE
Add a test case for #21

### DIFF
--- a/tests/Integration/ComposerUpdateHook.php
+++ b/tests/Integration/ComposerUpdateHook.php
@@ -14,7 +14,7 @@ final class ComposerUpdateHook implements BeforeFirstTestHook
         $command = sprintf(
             '%s && %s',
             $this->cwdToEnvironment(),
-            '[ -d vendor ] && composer dump || composer update -n --prefer-dist --no-progress --ignore-platform-reqs --no-plugins ' . $this->suppressLogs(),
+            '[ -d vendor ] && composer dump || composer update -n --prefer-dist --no-progress --ignore-platform-reqs ' . $this->suppressLogs(),
         );
         $this->exec($command);
     }

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -49,6 +49,10 @@
         {
             "type": "path",
             "url": "../Packages/second-dev-vendor/second-package"
+        },
+        {
+            "type": "path",
+            "url": "../../.."
         }
     ],
     "autoload": {
@@ -73,14 +77,5 @@
             "web": "config/web.php"
         },
         "config-plugin-alternatives": "config/alternatives.json"
-    },
-    "scripts": {
-        "symlink-package": [
-            "rm -rf vendor/yiisoft/composer-config-plugin",
-            "ln -s ../../../../../ vendor/yiisoft/composer-config-plugin",
-            "@composer dump"
-        ],
-        "post-install-cmd": "@symlink-package",
-        "post-update-cmd": "@symlink-package"
     }
 }


### PR DESCRIPTION
It is Composer 2 only. Doesn't work with Composer 1 since it doesn't allow "path" packages that are parents to the directory with `composer.json`.

| Q                    | A
| -------------------- | ---
| Bugfix?              | ❌
| Feature?             | ❌
| Break compatibility? | ❌
| Tests pass?          | ❌
| Fix issues           |  none. These are tests for #21
