### PR TITLE
Fix first run with package from packagist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,8 +11,10 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="Yiisoft\Composer\Config\Tests\Integration\ComposerUpdateHook"/>
-        <extension class="Yiisoft\Composer\Config\Tests\Integration\RebuildHook"/>
+        <extension class="Yiisoft\Composer\Config\Tests\Integration\Hooks\CopyPackageBeforeRunTestsHook"/>
+        <extension class="Yiisoft\Composer\Config\Tests\Integration\Hooks\ComposerUpdateHook"/>
+        <extension class="Yiisoft\Composer\Config\Tests\Integration\Hooks\RebuildHook"/>
+        <extension class="Yiisoft\Composer\Config\Tests\Integration\Hooks\RemovePackageAfterTestsHook"/>
     </extensions>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -49,6 +49,10 @@
         {
             "type": "path",
             "url": "../Packages/second-dev-vendor/second-package"
+        },
+        {
+            "type": "path",
+            "url": "../Packages/yiisoft/composer-config-plugin"
         }
     ],
     "autoload": {

--- a/tests/Integration/Hooks/ComposerUpdateHook.php
+++ b/tests/Integration/Hooks/ComposerUpdateHook.php
@@ -15,7 +15,7 @@ final class ComposerUpdateHook implements BeforeFirstTestHook
     public function executeBeforeFirstTest(): void
     {
         $originalDirectory = getcwd();
-        $newDirectory = PathHelper::realpath(__DIR__) . '/Environment';
+        $newDirectory = PathHelper::realpath(dirname(__DIR__)) . '/Environment';
 
         chdir($newDirectory);
 

--- a/tests/Integration/Hooks/ComposerUpdateHook.php
+++ b/tests/Integration/Hooks/ComposerUpdateHook.php
@@ -2,15 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Composer\Config\Tests\Integration;
+namespace Yiisoft\Composer\Config\Tests\Integration\Hooks;
 
 use PHPUnit\Runner\BeforeFirstTestHook;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
+use Yiisoft\Composer\Config\Tests\Integration\Support\DirectoryManipulatorTrait;
 use Yiisoft\Composer\Config\Util\PathHelper;
 
 final class ComposerUpdateHook implements BeforeFirstTestHook
 {
+    use DirectoryManipulatorTrait;
+
     public function executeBeforeFirstTest(): void
     {
         $originalDirectory = getcwd();
@@ -52,22 +53,5 @@ final class ComposerUpdateHook implements BeforeFirstTestHook
         if ((int) $returnCode !== 0) {
             throw new \RuntimeException("$command return code was $returnCode. $res");
         }
-    }
-
-    private function removeDirectoryRecursive(string $path): void
-    {
-        $iterator = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
-        $iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
-
-        /* @var \SplFileInfo $file */
-        foreach ($iterator as $file) {
-            if ($file->isLink() || $file->isFile()) {
-                unlink($file->getRealPath());
-            } elseif ($file->isDir()) {
-                rmdir($file->getRealPath());
-            }
-        }
-
-        rmdir($path);
     }
 }

--- a/tests/Integration/Hooks/CopyPackageBeforeRunTestsHook.php
+++ b/tests/Integration/Hooks/CopyPackageBeforeRunTestsHook.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Hooks;
+
+use PHPUnit\Runner\BeforeFirstTestHook;
+use Yiisoft\Composer\Config\Tests\Integration\Support\DirectoryManipulatorTrait;
+
+final class CopyPackageBeforeRunTestsHook implements BeforeFirstTestHook
+{
+    use DirectoryManipulatorTrait;
+
+    public function executeBeforeFirstTest(): void
+    {
+        $composerConfigPluginDirectory = __DIR__ . '/Packages/yiisoft/';
+        $pluginCurrentVersionDirectory = dirname(__DIR__, 3);
+
+        if (file_exists($composerConfigPluginDirectory)) {
+            $this->removeDirectoryRecursive($composerConfigPluginDirectory);
+        }
+
+        $this->copyDirectory($pluginCurrentVersionDirectory, $composerConfigPluginDirectory);
+    }
+}

--- a/tests/Integration/Hooks/CopyPackageBeforeRunTestsHook.php
+++ b/tests/Integration/Hooks/CopyPackageBeforeRunTestsHook.php
@@ -13,8 +13,8 @@ final class CopyPackageBeforeRunTestsHook implements BeforeFirstTestHook
 
     public function executeBeforeFirstTest(): void
     {
-        $composerConfigPluginDirectory = __DIR__ . '/Packages/yiisoft/';
-        $pluginCurrentVersionDirectory = dirname(__DIR__, 3);
+        $composerConfigPluginDirectory = dirname(__DIR__) . '/Packages/yiisoft/';
+        $pluginCurrentVersionDirectory = dirname(__DIR__, 4);
 
         if (file_exists($composerConfigPluginDirectory)) {
             $this->removeDirectoryRecursive($composerConfigPluginDirectory);

--- a/tests/Integration/Hooks/RebuildHook.php
+++ b/tests/Integration/Hooks/RebuildHook.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Composer\Config\Tests\Integration;
+namespace Yiisoft\Composer\Config\Tests\Integration\Hooks;
 
 use PHPUnit\Runner\BeforeFirstTestHook;
 use Yiisoft\Composer\Config\Builder;

--- a/tests/Integration/Hooks/RebuildHook.php
+++ b/tests/Integration/Hooks/RebuildHook.php
@@ -15,7 +15,7 @@ final class RebuildHook implements BeforeFirstTestHook
         if (!(bool) ($_SERVER['REBUILD'] ?? false)) {
             return;
         }
-        $baseDir = PathHelper::realpath(__DIR__) . '/Environment';
+        $baseDir = PathHelper::realpath(dirname(__DIR__)) . '/Environment';
 
         require_once $baseDir . '/vendor/autoload.php';
         echo 'Rebuild configs...' . PHP_EOL;

--- a/tests/Integration/Hooks/RemovePackageAfterTestsHook.php
+++ b/tests/Integration/Hooks/RemovePackageAfterTestsHook.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Hooks;
+
+use PHPUnit\Runner\AfterLastTestHook;
+use Yiisoft\Composer\Config\Tests\Integration\Support\DirectoryManipulatorTrait;
+
+final class RemovePackageAfterTestsHook implements AfterLastTestHook
+{
+    use DirectoryManipulatorTrait;
+
+    public function executeAfterLastTest(): void
+    {
+        $composerConfigPluginDirectory = __DIR__ . '/Packages/yiisoft/';
+
+        $this->removeDirectoryRecursive($composerConfigPluginDirectory);
+    }
+}

--- a/tests/Integration/Hooks/RemovePackageAfterTestsHook.php
+++ b/tests/Integration/Hooks/RemovePackageAfterTestsHook.php
@@ -13,7 +13,7 @@ final class RemovePackageAfterTestsHook implements AfterLastTestHook
 
     public function executeAfterLastTest(): void
     {
-        $composerConfigPluginDirectory = __DIR__ . '/Packages/yiisoft/';
+        $composerConfigPluginDirectory = dirname(__DIR__) . '/Packages/yiisoft/';
 
         $this->removeDirectoryRecursive($composerConfigPluginDirectory);
     }

--- a/tests/Integration/Packages/.gitignore
+++ b/tests/Integration/Packages/.gitignore
@@ -1,0 +1,1 @@
+yiisoft/

--- a/tests/Integration/Support/DirectoryManipulatorTrait.php
+++ b/tests/Integration/Support/DirectoryManipulatorTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Support;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+trait DirectoryManipulatorTrait
+{
+    public function copyDirectory(string $source, string $destination): void
+    {
+        mkdir($destination);
+
+        $directoryIterator = new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS);
+        $ignoredFolders = ['.idea', '.git', '.github', 'tests', 'vendor'];
+        $filer = new \RecursiveCallbackFilterIterator($directoryIterator,
+            static function ($current, $key, \DirectoryIterator $iterator) use ($ignoredFolders) {
+                return !in_array($iterator->getFilename(), $ignoredFolders);
+            });
+        $iterator = new RecursiveIteratorIterator($filer, RecursiveIteratorIterator::SELF_FIRST);
+        /* @var $item \SplFileInfo */
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                mkdir($destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+            } else {
+                copy($item->getPathname(), $destination . DIRECTORY_SEPARATOR . $iterator->getSubPathName());
+            }
+        }
+    }
+
+    public function removeDirectoryRecursive(string $path): void
+    {
+        $iterator = new RecursiveDirectoryIterator($path, RecursiveDirectoryIterator::SKIP_DOTS);
+        $iterator = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
+
+        /* @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->isLink() || $file->isFile()) {
+                unlink($file->getRealPath());
+            } elseif ($file->isDir()) {
+                rmdir($file->getRealPath());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Integration/Support/DirectoryManipulatorTrait.php
+++ b/tests/Integration/Support/DirectoryManipulatorTrait.php
@@ -15,10 +15,12 @@ trait DirectoryManipulatorTrait
 
         $directoryIterator = new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS);
         $ignoredFolders = ['.idea', '.git', '.github', 'tests', 'vendor'];
-        $filer = new \RecursiveCallbackFilterIterator($directoryIterator,
+        $filer = new \RecursiveCallbackFilterIterator(
+            $directoryIterator,
             static function ($current, $key, \DirectoryIterator $iterator) use ($ignoredFolders) {
                 return !in_array($iterator->getFilename(), $ignoredFolders);
-            });
+            }
+        );
         $iterator = new RecursiveIteratorIterator($filer, RecursiveIteratorIterator::SELF_FIRST);
         /* @var $item \SplFileInfo */
         foreach ($iterator as $item) {


### PR DESCRIPTION
| Q                    | A
| -------------------- | ---
| Bugfix?              | ✔️
| Feature?             | ❌
| Break compatibility? | ❌
| Tests pass?          | ✔️

In Travis the first test suite (witout rebuild) is running with package version from packagist (not symlinked to "current" package).
This PR fix this wrong behaviour
