### PR TITLE
Fixes #99 Add support override $params via "$params = $another-params".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ coverage.clover
 # dynamic files
 .phpunit.result.cache
 
+# local phpunit config
+/phpunit.xml
+
 # Binaries
 chkipper.phar
 composer.phar

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -33,6 +33,11 @@ class Builder
      */
     private array $configs = [];
 
+    /**
+     * @var array
+     */
+    private array $paramsConfigs;
+
     private ConfigFactory $configFactory;
 
     /**
@@ -157,6 +162,25 @@ class Builder
     private static function isAbsolutePath(string $path): bool
     {
         return strpos($path, '/') === 0 || strpos($path, ':') === 1 || strpos($path, '\\\\') === 0;
+    }
+
+    /**
+     * @param array $paramsConfigs
+     * @return void
+     */
+    public function setParamsConfigs(array $paramsConfigs): void
+    {
+        $this->paramsConfigs = $paramsConfigs;
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function getConfigParams(string $name): array
+    {
+        $paramsConfigName = isset($this->paramsConfigs[$name]) ? $this->paramsConfigs[$name] : 'params';
+        return isset($this->configs[$paramsConfigName]) ? $this->configs[$paramsConfigName]->getValues() : [];
     }
 
     /**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -104,7 +104,7 @@ class Config
      */
     protected function loadFile(string $path): array
     {
-        $reader = ReaderFactory::get($this->builder, $path);
+        $reader = ReaderFactory::get($this->builder, $path, $this->builder->getConfigParams($this->name));
 
         return $reader->read($path);
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -42,6 +42,11 @@ final class Plugin
      */
     private array $originalFiles = [];
 
+    /**
+     * @var array
+     */
+    private array $paramsConfigs = [];
+
     private Builder $builder;
 
     /**
@@ -85,6 +90,7 @@ final class Plugin
         $this->scanPackages();
         $this->reorderFiles();
 
+        $this->builder->setParamsConfigs($this->paramsConfigs);
         $this->builder->buildAllConfigs($this->files);
 
         $saveFiles = $this->files;
@@ -228,7 +234,11 @@ final class Plugin
                 $paths = array_reverse($paths);
             }
             foreach ($paths as $path) {
-                $this->addFile($package, $name, $path);
+                if (preg_match('/^\$params\s*\=\s*\$(.+)$/', $path, $matches)) {
+                    $this->paramsConfigs[$name] = $matches[1];
+                } else {
+                    $this->addFile($package, $name, $path);
+                }
             }
         }
     }

--- a/src/Reader/PhpReader.php
+++ b/src/Reader/PhpReader.php
@@ -7,17 +7,24 @@ namespace Yiisoft\Composer\Config\Reader;
 /**
  * PhpReader - reads PHP files.
  */
-class PhpReader extends AbstractReader
+class PhpReader extends AbstractReader implements ReaderWithParamsInterface
 {
+    private $params = [];
+
     protected function readRaw(string $path)
     {
         $result = static function () {
             /** @noinspection NonSecureExtractUsageInspection */
-            extract(func_get_arg(0));
+            $params = func_get_arg(0) ;
 
             return require func_get_arg(1);
         };
 
-        return $result($this->builder->getVars(), $path);
+        return $result($this->params, $path);
+    }
+
+    public function setParams(array $params): void
+    {
+        $this->params = $params;
     }
 }

--- a/src/Reader/ReaderFactory.php
+++ b/src/Reader/ReaderFactory.php
@@ -22,7 +22,7 @@ class ReaderFactory
         'yml' => YamlReader::class,
     ];
 
-    public static function get(Builder $builder, string $path): ReaderInterface
+    public static function get(Builder $builder, string $path, array $params = []): ReaderInterface
     {
         $type = static::detectType($path);
         $class = static::findClass($type);
@@ -30,6 +30,10 @@ class ReaderFactory
         $uniqid = $class . ':' . spl_object_hash($builder);
         if (empty(self::$loaders[$uniqid])) {
             self::$loaders[$uniqid] = new $class($builder);
+        }
+
+        if (self::$loaders[$uniqid] instanceof ReaderWithParamsInterface) {
+            self::$loaders[$uniqid]->setParams($params);
         }
 
         return self::$loaders[$uniqid];

--- a/src/Reader/ReaderWithParamsInterface.php
+++ b/src/Reader/ReaderWithParamsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Reader;
+
+interface ReaderWithParamsInterface
+{
+    public function setParams(array $params): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #99 

For example, see string **"$params = $params-app-main"**:

```
"params": "config/common/params.php",
"params-app-main": [
	"$params",
	"config/app-main/params.php"
],
"common": "config/common/common.php",
"web": "config/common/web.php",
"app-main": [
	"$params = $params-app-main",
	"$common",
	"$web",
	"config/app-main/main.php"
],
```

Breaked: in php configs remove all variables, available only var `$params`.