### PR TITLE
Add override $params via extra-parameter "config-plugin-override-params"

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -33,6 +33,11 @@ class Builder
      */
     private array $configs = [];
 
+    /**
+     * @var array
+     */
+    private array $overrideParams = [];
+
     private ConfigFactory $configFactory;
 
     /**
@@ -157,6 +162,27 @@ class Builder
     private static function isAbsolutePath(string $path): bool
     {
         return strpos($path, '/') === 0 || strpos($path, ':') === 1 || strpos($path, '\\\\') === 0;
+    }
+
+    /**
+     * @param array $overrideParams
+     * @return void
+     */
+    public function mergeOverrideParams(array $overrideParams): void
+    {
+        if ($overrideParams) {
+            $this->overrideParams = array_merge($this->overrideParams, $overrideParams);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return array
+     */
+    public function getConfigParams(string $name): array
+    {
+        $paramsConfigName = $this->overrideParams[$name] ?? 'params';
+        return isset($this->configs[$paramsConfigName]) ? $this->configs[$paramsConfigName]->getValues() : [];
     }
 
     /**

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -104,7 +104,7 @@ class Config
      */
     protected function loadFile(string $path): array
     {
-        $reader = ReaderFactory::get($this->builder, $path);
+        $reader = ReaderFactory::get($this->builder, $path, $this->builder->getConfigParams($this->name));
 
         return $reader->read($path);
     }

--- a/src/Package.php
+++ b/src/Package.php
@@ -8,6 +8,7 @@ use Composer\Package\CompletePackageInterface;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Util\Filesystem;
+use RuntimeException;
 
 /**
  * Class Package.
@@ -17,6 +18,7 @@ class Package
     public const EXTRA_FILES_OPTION_NAME = 'config-plugin';
     public const EXTRA_DEV_FILES_OPTION_NAME = 'config-plugin-dev';
     public const EXTRA_OUTPUT_DIR_OPTION_NAME = 'config-plugin-output-dir';
+    public const EXTRA_OVERRIDE_PARAMS_OPTION_NAME = 'config-plugin-override-params';
     public const EXTRA_ALTERNATIVES_OPTION_NAME = 'config-plugin-alternatives';
 
     private PackageInterface $package;
@@ -233,5 +235,16 @@ class Package
     public function getBaseDir(): string
     {
         return $this->baseDir;
+    }
+
+    public function getOverrideParams(): array
+    {
+        $overrideParams = $this->getExtraValue(self::EXTRA_OVERRIDE_PARAMS_OPTION_NAME, []);
+        return array_map(function ($name) {
+            if (strpos($name, '$') !== 0) {
+                throw new RuntimeException('For override params use variable, for example "$params-another".');
+            }
+            return substr($name, 1);
+        }, $overrideParams);
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -182,6 +182,8 @@ final class Plugin
             }
         }
 
+        $this->builder->mergeOverrideParams($package->getOverrideParams());
+
         $aliases = $this->aliasesCollector->collect($package);
 
         $this->builder->mergeAliases($aliases);
@@ -223,7 +225,7 @@ final class Plugin
     private function addFiles(Package $package, array $files): void
     {
         foreach ($files as $name => $paths) {
-            $paths = (array) $paths;
+            $paths = (array)$paths;
             if ('constants' === $name) {
                 $paths = array_reverse($paths);
             }

--- a/src/Reader/PhpReader.php
+++ b/src/Reader/PhpReader.php
@@ -7,25 +7,27 @@ namespace Yiisoft\Composer\Config\Reader;
 /**
  * PhpReader - reads PHP files.
  */
-class PhpReader extends AbstractReader
+class PhpReader extends AbstractReader implements ReaderWithParamsInterface
 {
+
+    private array $params = [];
+
     protected function readRaw(string $path)
     {
-        $params = [];
         $config = [];
-
         foreach ($this->builder->getVars() as $key => $parameters) {
-            if ($key === 'params') {
-                $params = (array)$parameters;
-            } else {
-                $config[$key] = $parameters;
-            }
+            $config[$key] = $parameters;
         }
 
         $result = static function (array $params, array $config) {
             return require func_get_arg(2);
         };
 
-        return $result($params, $config, $path);
+        return $result($this->params, $config, $path);
+    }
+
+    public function setParams(array $params): void
+    {
+        $this->params = $params;
     }
 }

--- a/src/Reader/ReaderFactory.php
+++ b/src/Reader/ReaderFactory.php
@@ -22,7 +22,7 @@ class ReaderFactory
         'yml' => YamlReader::class,
     ];
 
-    public static function get(Builder $builder, string $path): ReaderInterface
+    public static function get(Builder $builder, string $path, array $params = []): ReaderInterface
     {
         $type = static::detectType($path);
         $class = static::findClass($type);
@@ -30,6 +30,10 @@ class ReaderFactory
         $uniqid = $class . ':' . spl_object_hash($builder);
         if (empty(self::$loaders[$uniqid])) {
             self::$loaders[$uniqid] = new $class($builder);
+        }
+
+        if (self::$loaders[$uniqid] instanceof ReaderWithParamsInterface) {
+            self::$loaders[$uniqid]->setParams($params);
         }
 
         return self::$loaders[$uniqid];

--- a/src/Reader/ReaderWithParamsInterface.php
+++ b/src/Reader/ReaderWithParamsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Reader;
+
+interface ReaderWithParamsInterface
+{
+    public function setParams(array $params): void;
+}

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -66,6 +66,9 @@
         }
     },
     "extra": {
+        "config-plugin-override-params": {
+            "another": "$params-another"
+        },
         "config-plugin": {
             "constants": "config/constants.php",
             "params": [
@@ -73,8 +76,10 @@
                 "config/params.yaml",
                 "config/params.json"
             ],
+            "params-another": "config/params-another.php",
             "test": "config/test.php",
-            "web": "config/web.php"
+            "web": "config/web.php",
+            "another": "config/another.php"
         },
         "config-plugin-alternatives": "config/alternatives.json"
     },

--- a/tests/Integration/Environment/composer.json
+++ b/tests/Integration/Environment/composer.json
@@ -67,7 +67,8 @@
     },
     "extra": {
         "config-plugin-override-params": {
-            "another": "$params-another"
+            "another": "$params-another",
+            "second": "$params-second-override"
         },
         "config-plugin": {
             "constants": "config/constants.php",
@@ -79,7 +80,8 @@
             "params-another": "config/params-another.php",
             "test": "config/test.php",
             "web": "config/web.php",
-            "another": "config/another.php"
+            "another": "config/another.php",
+            "params-second-override": "config/params-second-override.php"
         },
         "config-plugin-alternatives": "config/alternatives.json"
     },

--- a/tests/Integration/Environment/config/another.php
+++ b/tests/Integration/Environment/config/another.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var $params array */
+
+return [
+    'params' => $params,
+];

--- a/tests/Integration/Environment/config/params-another.php
+++ b/tests/Integration/Environment/config/params-another.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'boolean parameter' => false,
+];

--- a/tests/Integration/Environment/config/params-second-override.php
+++ b/tests/Integration/Environment/config/params-second-override.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'value' => false,
+];

--- a/tests/Integration/Packages/first-vendor/first-package/composer.json
+++ b/tests/Integration/Packages/first-vendor/first-package/composer.json
@@ -6,9 +6,14 @@
         }
     },
     "extra": {
+        "config-plugin-override-params": {
+            "first": "$params-first"
+        },
         "config-plugin": {
             "constants": "config/constants.php",
-            "params": "config/params.php"
+            "params": "config/params.php",
+            "params-first": "config/params-first.php",
+            "first": "config/first.php"
         }
     }
 }

--- a/tests/Integration/Packages/first-vendor/first-package/config/first.php
+++ b/tests/Integration/Packages/first-vendor/first-package/config/first.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var $params array */
+
+return [
+    'params' => $params,
+];

--- a/tests/Integration/Packages/first-vendor/first-package/config/params-first.php
+++ b/tests/Integration/Packages/first-vendor/first-package/config/params-first.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'value' => true,
+];

--- a/tests/Integration/Packages/first-vendor/second-package/composer.json
+++ b/tests/Integration/Packages/first-vendor/second-package/composer.json
@@ -6,9 +6,14 @@
         }
     },
     "extra": {
+        "config-plugin-override-params": {
+            "second": "$params-second"
+        },
         "config-plugin": {
             "constants": "config/constants.php",
-            "params": "config/params.php"
+            "params": "config/params.php",
+            "params-second": "config/params-second.php",
+            "second": "config/second.php"
         }
     }
 }

--- a/tests/Integration/Packages/first-vendor/second-package/config/params-second.php
+++ b/tests/Integration/Packages/first-vendor/second-package/config/params-second.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'value' => true,
+];

--- a/tests/Integration/Packages/first-vendor/second-package/config/second.php
+++ b/tests/Integration/Packages/first-vendor/second-package/config/second.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+/** @var $params array */
+
+return [
+    'params' => $params,
+];

--- a/tests/Integration/Tests/Config/AnotherConfigTest.php
+++ b/tests/Integration/Tests/Config/AnotherConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
+
+final class AnotherConfigTest extends ConfigTest
+{
+
+    public function configProvider(): array
+    {
+        return [
+            [
+                'params',
+                fn(array $params) => $this->assertFalse($params['boolean parameter']),
+            ],
+        ];
+    }
+
+    protected function getDefaultConfigName(): string
+    {
+        return 'another';
+    }
+}

--- a/tests/Integration/Tests/Config/FirstPackageConfigTest.php
+++ b/tests/Integration/Tests/Config/FirstPackageConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
+
+final class FirstPackageConfigTest extends ConfigTest
+{
+
+    public function configProvider(): array
+    {
+        return [
+            [
+                'params',
+                fn(array $params) => $this->assertTrue($params['value']),
+            ],
+        ];
+    }
+
+    protected function getDefaultConfigName(): string
+    {
+        return 'first';
+    }
+}

--- a/tests/Integration/Tests/Config/SecondPackageConfigTest.php
+++ b/tests/Integration/Tests/Config/SecondPackageConfigTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Composer\Config\Tests\Integration\Tests\Config;
+
+final class SecondPackageConfigTest extends ConfigTest
+{
+
+    public function configProvider(): array
+    {
+        return [
+            [
+                'params',
+                fn(array $params) => $this->assertFalse($params['value']),
+            ],
+        ];
+    }
+
+    protected function getDefaultConfigName(): string
+    {
+        return 'second';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |  ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #99 

Example:

```
"extra": {
	"config-plugin-override-params": {
		"another": "$params-another"
	},
	"config-plugin": {
		...
		"params-another": "config/params-another.php",
		"another": "config/another.php"
	}
},
```

One test is failed. Will be pass after PR #110 