### PR TITLE
fix file extension duplicate in "Builder::require"

### DIFF
--- a/src/Util/BuilderRequireEncoder.php
+++ b/src/Util/BuilderRequireEncoder.php
@@ -33,11 +33,13 @@ class BuilderRequireEncoder implements Encoder
     {
         $reflection = new ReflectionClosure($value);
         $variables = $reflection->getStaticVariables();
-        $config = $variables['config'];
+        $config = strrpos($variables['config'], '.php') === false
+            ? $variables['config'] . '.php'
+            : $variables['config'];
 
         return str_replace(
             ['$config'],
-            ["'$config.php'"],
+            ["'$config'"],
             substr(
                 $reflection->getCode(),
                 16

--- a/src/Util/BuilderRequireEncoder.php
+++ b/src/Util/BuilderRequireEncoder.php
@@ -33,13 +33,15 @@ class BuilderRequireEncoder implements Encoder
     {
         $reflection = new ReflectionClosure($value);
         $variables = $reflection->getStaticVariables();
-        $config = strrpos($variables['config'], '.php') === false
-            ? $variables['config'] . '.php'
-            : $variables['config'];
+        $config = $variables['config'];
+
+        if (pathinfo($config, PATHINFO_EXTENSION) === '') {
+            $config = $config . '.php';
+        }
 
         return str_replace(
             ['$config'],
-            ["'$config'"],
+            ["'$config.php'"],
             substr(
                 $reflection->getCode(),
                 16


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

When using 
```php 
Builder::require(Builder::path('routes')) 
```
returns ```src/config/routes.php.php``` 
expected ```src/config/routes.php```